### PR TITLE
Added ability to limit number of results

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ foreach ($books->volumes->search('Hello world') as $vol) {
 Note that the `search()` method returns a generator
 that automatically fetches more results until the result
 list is depleted. If there are thousands of results this will of course take a *long*
-time to fetch, so you probably want to define a limit.
+time to fetch, so you probably want to define a limit. Limits  can be defined as an option: `['maxResults' => 10]` inside the `GoogleBooks` class.
 
 ### Working with bookshelves
 

--- a/src/GoogleBooks.php
+++ b/src/GoogleBooks.php
@@ -46,6 +46,11 @@ class GoogleBooks
      * @var Bookshelves
      */
     public $bookshelves;
+    
+    /**
+     * @var maxResults
+     */
+    public $maxResults;
 
     public function __construct($options = [])
     {
@@ -61,6 +66,8 @@ class GoogleBooks
         $this->bookshelves = new Bookshelves($this);
 
         $this->batchSize = isset($options['batchSize']) ? $options['batchSize'] : 40;
+
+        $this->maxResults = isset($options['maxResults']) ? $options['maxResults'] : null;
     }
 
     protected function raw($endpoint, $params = [], $method='GET')
@@ -71,6 +78,11 @@ class GoogleBooks
         if (!is_null($this->country)) {
             $params['country'] = $this->country;
         }
+
+        if (!is_null($this->maxResults)) {
+            $params['maxResults'] = $this->maxResults;
+        }
+
         try {
             $response = $this->http->request($method, $endpoint, [
                 'query' => $params,


### PR DESCRIPTION
Added a ['maxResults' => integer_here] capability inside the GoogleBooks class so that results can be limited to a certain amount. This speeds up the time it takes to fetch results.

the option can be added like the other options when instantiating the class.

### Example

    $books = new GoogleBooks(['maxResults' => 15]); 