### PR TITLE
Limit method

### DIFF
--- a/src/GoogleBooks.php
+++ b/src/GoogleBooks.php
@@ -119,6 +119,12 @@ class GoogleBooks
         return $this->raw($path);
     }
 
+    public function limit(int $maxResults)
+    {
+        $this->maxResults = $maxResults;
+        return $this;
+    }
+
     public function listItems($endpoint, $params = [])
     {
         $params['maxResults'] = $this->batchSize;


### PR DESCRIPTION
It's important to have a setter on the `GoogleBooks` class for 3 reasons.

- this makes it possible to change the max results returning with the same instantiated class 
- multiple searches of different limits can be made with the same instantiated class.
- prevents having to reinstate the class if we want to change options.

can be used as: 

```php
$firstBookSearch = $books->limit(20)->volumes->search('book title');
$secondBookSearch = $books->limit(10)->volumes->search('another title');
```

most properties / options should have setters anyway