### PR TITLE
added support for chunking

### DIFF
--- a/src/GoogleBooks.php
+++ b/src/GoogleBooks.php
@@ -119,6 +119,15 @@ class GoogleBooks
         return $this->raw($path);
     }
 
+    public function chunk(\Generator $generator, int $chunkInt)
+    {
+        $chunk = [];
+        foreach ($generator as $gen) {
+            $chunk[] = $generator->current();
+        }
+        return array_chunk($chunk, $chunkInt);
+    }
+
     public function listItems($endpoint, $params = [])
     {
         $params['maxResults'] = $this->batchSize;

--- a/src/Volumes.php
+++ b/src/Volumes.php
@@ -6,6 +6,7 @@ namespace Scriptotek\GoogleBooks;
 class Volumes
 {
     protected $client;
+    protected $chunk = false;
 
     public function __construct(GoogleBooks $client)
     {
@@ -14,13 +15,35 @@ class Volumes
 
     /**
      * @param $query
-     * @return \Generator|Volume
+     * @return \Generator|Volume || array
      */
     public function search($query)
+    {
+        if ($this->chunk) {
+            return $this->client->chunk($this->fetchSearch($query), $this->chunk);
+        }
+        return $this->fetchSearch($query);
+    }
+
+    /**
+     * @param $query
+     * @return \Generator|Volume
+     */
+    private function fetchSearch($query)
     {
         foreach ($this->client->listItems('volumes', ['q' => $query]) as $item) {
             yield new Volume($this->client, $item);
         }
+    }
+
+    /**
+     * @param $chunk
+     * @return Volumes
+     */
+    public function chunk(int $chunk)
+    {
+        $this->chunk = $chunk;
+        return $this;
     }
 
     public function firstOrNull($query)


### PR DESCRIPTION
Using this library in a view works until you need to chunk for layout purposes. Before, an array_chunk could not accept the results as a parameter because a generator is returned. Simply adding a `chunk(int)` in the search now results in an array being returned.

### Problem

This was not possible so it was not possible to make a good layout
```blade
@foreach($results as $bookChunk)
                
    <div class="row"> <!-- row here -->
         @foreach ($bookChunk as $book)
             <div class="col-md-4"></div> <!-- col here -->
         @endforeach
    </div>

@endforeach
```

### Example

```php
$books = new GoogleBooks();
    
$results = $books->limit(20)->volumes->chunk(3)->search($_GET['search']);
```

