### PR TITLE
Fixed typo in class name of InvalidConfiguration

### DIFF
--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -4,7 +4,7 @@ namespace Scriptotek\GoogleBooks\Exceptions;
 
 use Exception;
 
-class InvalidCOnfiguration extends Exception
+class InvalidConfiguration extends Exception
 {
     public static function keyNotSpecified()
     {


### PR DESCRIPTION
This was detected as composer complained about PSR-4 standard violation:

Deprecation Notice: Class Scriptotek\GoogleBooks\Exceptions\InvalidCOnfiguration located in .../vendor/scriptotek/google-books/src\Exceptions\InvalidConfiguration.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar://C:/ProgramData/ComposerSetup/bin/composer.phar/src/Composer/Autoload/ClassMapGenerator.php:201