### PR TITLE
Update GuzzleHttp version constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 vendor
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Package for interacting with the Google Books API",
     "homepage": "http://github.com/scriptotek/google-books",
     "require": {
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2|^7"
     },
     "require-dev": {
         "phpspec/phpspec": ">=2",

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "scriptotek/google-books",
+    "name": "foradev/google-books",
     "type": "library",
-    "description": "Package for interacting with the Google Books API",
-    "homepage": "http://github.com/scriptotek/google-books",
+    "description": "Package for interacting with the Google Books API. Forked from scriptotek/google-books",
+    "homepage": "http://github.com/foradev/google-books",
     "require": {
         "guzzlehttp/guzzle": "^6.2|^7"
     },
@@ -13,8 +13,8 @@
     "license": "ISC",
     "authors": [
         {
-            "name": "Dan Michael O. Heggø",
-            "email": "danmichaelo@gmail.com"
+            "name": "Francesco Abeni",
+            "email": "f.abeni@ora.dev"
         }
     ],
     "autoload": {


### PR DESCRIPTION
This package works fine even if it's not been modified since many years. This PR makes a minor modification to composer dependencies so that it can also use GuzzleHttp version 7. I tested with a forked and modified version of your package and everything seems to be working fine.
Thank you.